### PR TITLE
Update S3 bucket to allow force destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "random_id" "suffix" {
 resource "aws_s3_bucket" "demo_bucket" {
   bucket = "${var.bucket_prefix}-${random_id.suffix.hex}"
   acl    = "private"
+  force_destroy = true
 
   tags = {
     Name        = "Demo Bucket"


### PR DESCRIPTION
## Summary
- add `force_destroy` to `aws_s3_bucket.demo_bucket`

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b89f1afc8330b9db988267a1c4ea