### PR TITLE
Add configurable S3 features and version constraints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0, < 4.0"
+    }
+  }
+}
+
 provider "aws" {
   region = var.region
 }
@@ -9,10 +24,26 @@ resource "random_id" "suffix" {
 resource "aws_s3_bucket" "demo_bucket" {
   bucket        = "${var.bucket_prefix}-${random_id.suffix.hex}"
   acl           = "private"
-  force_destroy = true
+  force_destroy = var.force_destroy
 
-  tags = {
-    Name        = "Demo Bucket"
-    Environment = "Dev"
+  tags = var.bucket_tags
+}
+
+resource "aws_s3_bucket_versioning" "demo" {
+  bucket = aws_s3_bucket.demo_bucket.id
+
+  versioning_configuration {
+    status = var.enable_versioning ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "demo" {
+  count  = var.enable_sse ? 1 : 0
+  bucket = aws_s3_bucket.demo_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,2 @@
+region        = "us-west-2"
+bucket_prefix = "my-demo-bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,30 @@ variable "bucket_prefix" {
   description = "Prefix for the S3 bucket name"
   default     = "berke-demo-bucket"
 }
+
+variable "force_destroy" {
+  description = "Whether to force destroy the S3 bucket"
+  type        = bool
+  default     = true
+}
+
+variable "bucket_tags" {
+  description = "Map of tags to apply to the S3 bucket"
+  type        = map(string)
+  default = {
+    Name        = "Demo Bucket"
+    Environment = "Dev"
+  }
+}
+
+variable "enable_versioning" {
+  description = "Enable versioning on the S3 bucket"
+  type        = bool
+  default     = true
+}
+
+variable "enable_sse" {
+  description = "Enable server-side encryption on the S3 bucket"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- add a `terraform` block with pinned provider versions
- expose configuration variables for bucket tags, force destroy flag, SSE and versioning
- enable versioning and optional encryption via additional resources
- provide an example `terraform.tfvars.example`

## Testing
- `terraform fmt -recursive`
- `terraform init -input=false` *(fails: could not query provider packages)*
- `terraform validate` *(fails: missing required providers)*

------
https://chatgpt.com/codex/tasks/task_e_6859c4d8e828833097d7be6db116a2fd